### PR TITLE
Add partial support for pack format v2

### DIFF
--- a/godotdec/Program.cs
+++ b/godotdec/Program.cs
@@ -41,7 +41,7 @@ namespace godotdec {
 				Bio.Cout($"Package format version: {packFormatVersion}");
 				Bio.Cout($"Godot Engine version: {inputStream.ReadInt32()}.{inputStream.ReadInt32()}.{inputStream.ReadInt32()}");
 
-				if (packFormatVersion == 1)
+				if (packFormatVersion <= 1)
 				{
 					// No special handling
 				}

--- a/godotdec/Program.cs
+++ b/godotdec/Program.cs
@@ -1,4 +1,4 @@
-﻿using BioLib;
+using BioLib;
 using BioLib.Streams;
 using System;
 using System.Collections.Generic;
@@ -37,7 +37,30 @@ namespace godotdec {
 					CheckMagic(inputStream.ReadInt32());
 				}
 				
-				Bio.Cout($"Godot Engine version: {inputStream.ReadInt32()}.{inputStream.ReadInt32()}.{inputStream.ReadInt32()}.{inputStream.ReadInt32()}");
+				int packFormatVersion = inputStream.ReadInt32();
+				Bio.Cout($"Package format version: {packFormatVersion}");
+				Bio.Cout($"Godot Engine version: {inputStream.ReadInt32()}.{inputStream.ReadInt32()}.{inputStream.ReadInt32()}");
+
+				if (packFormatVersion == 1)
+				{
+					// No special handling
+				}
+				else if (packFormatVersion == 2)
+				{
+					uint packFlags = inputStream.ReadUInt32();
+					if ((packFlags & 1) != 0) // PACK_DIR_ENCRYPTED
+						Bio.Error("Encrypted directory not supported.", Bio.EXITCODE.NOT_SUPPORTED);
+                }
+				else
+				{
+					Bio.Error("Package format version not supported.", Bio.EXITCODE.NOT_SUPPORTED);
+				}
+
+				long filesBase = 0;
+				if (packFormatVersion >= 2)
+				{
+					filesBase = inputStream.ReadInt64();
+				}
 
 				// Skip reserved bytes (16x Int32)
 				inputStream.BaseStream.Skip(16 * 4);
@@ -54,6 +77,12 @@ namespace godotdec {
 					fileIndex.Add(fileEntry);
 					Bio.Debug(fileEntry);
 					inputStream.BaseStream.Skip(16);
+					if (packFormatVersion >= 2)
+					{
+						uint fileFlags = inputStream.ReadUInt32();
+						if ((fileFlags & 1) != 0)
+                            Bio.Error("Encrypted files not supported.", Bio.EXITCODE.NOT_SUPPORTED);
+                    }
 					//break;
 				}
 
@@ -61,6 +90,14 @@ namespace godotdec {
 				fileIndex.Sort((a, b) => (int) (a.offset - b.offset));
 
 				var fileIndexEnd = inputStream.BaseStream.Position;
+				if (packFormatVersion >= 2)
+				{
+					foreach (var fileEntry in fileIndex)
+					{
+						fileEntry.offset += filesBase;
+					}
+				}
+
 				for (var i = 0; i < fileIndex.Count; i++) {
 					var fileEntry = fileIndex[i];
 					Bio.Progress(fileEntry.path, i+1, fileIndex.Count);

--- a/godotdec/Program.cs
+++ b/godotdec/Program.cs
@@ -1,4 +1,4 @@
-using BioLib;
+﻿using BioLib;
 using BioLib.Streams;
 using System;
 using System.Collections.Generic;
@@ -132,7 +132,7 @@ namespace godotdec {
 
 					try {
 						Action<Stream, Stream> copyFunction = (input, output) => input.Copy(output, (int) fileEntry.size);
-						inputStream.BaseStream.WriteToFile(destination, PROMPT_ID, copyFunction);
+						inputStream.BaseStream.WriteToFileRelative(destination, PROMPT_ID, copyFunction);
 					}
 					catch (Exception e) {
 						Bio.Error(e);


### PR DESCRIPTION
Per title. Encrypted directory/files are not supported because it requires an external password to be input, and I don't have examples for such. Note due to the new aligned start of data and the alignment not being recorded in the pack, I'm using the base data offset from pack as-is, and hence you can't extract a .pck that was extracted from a .exe, only directly from the .exe itself, which seems to work fine.

Sidenote: significantly changing the behavior of a function instead of just making it a new function is recipe for confusion.

Fixes #1 and fixes #2 